### PR TITLE
优化custom目录是否存在

### DIFF
--- a/x86/diy-part2.sh
+++ b/x86/diy-part2.sh
@@ -14,7 +14,7 @@ function merge_package(){
     pkg=`echo $2 | rev | cut -d'/' -f 1 | rev`
     # find package/ -follow -name $pkg -not -path "package/custom/*" | xargs -rt rm -rf
     git clone --depth=1 --single-branch $1
-    [ -d package/custom ] || mkdir package/custom
+    [ -d package/custom ] || mkdir -p package/custom
     mv $2 package/custom/
     rm -rf $repo
 }

--- a/x86/diy-part2.sh
+++ b/x86/diy-part2.sh
@@ -14,6 +14,7 @@ function merge_package(){
     pkg=`echo $2 | rev | cut -d'/' -f 1 | rev`
     # find package/ -follow -name $pkg -not -path "package/custom/*" | xargs -rt rm -rf
     git clone --depth=1 --single-branch $1
+    [ -d package/custom ] || mkdir package/custom
     mv $2 package/custom/
     rm -rf $repo
 }


### PR DESCRIPTION
如果custom目录不存在，第一个拉取的文件夹内容会直接分散到custom下。第二个以后的正常。比如，第一次拉取luci-app-ssr.结果就是custom/(luci-app-ssr文件夹里面的内容)，而不是luci-app-ssr/(luci-app-ssr文件夹里面的内容)。拉取第二个及以后的文件夹因为custom路径存在，就正常了，所以加上这句判断custom不存在就新建，就正常了